### PR TITLE
update scm rockspec url

### DIFF
--- a/dist/basexx-scm-0.rockspec
+++ b/dist/basexx-scm-0.rockspec
@@ -9,7 +9,8 @@ description = {
 }
 
 source = {
-   url = "..."
+   url = "https://github.com/aiq/basexx/archive/master.tar.gz",
+   dir = "basexx-master",
 }
 
 dependencies = {


### PR DESCRIPTION
to allow for better automation (especially nix one).

I am trying to automate the packaging of lua packages in nix (an overarching package manager) in https://github.com/NixOS/nixpkgs/pull/134336 . basexx causes some issues because its scm source is a bit weird.